### PR TITLE
Fix vendor panel layout wrapping on iOS

### DIFF
--- a/client/src/commonMain/kotlin/com/neomud/client/ui/components/VendorPanel.kt
+++ b/client/src/commonMain/kotlin/com/neomud/client/ui/components/VendorPanel.kt
@@ -367,21 +367,38 @@ private fun BuyItemRow(
                     color = VerdantUpgrade
                 )
             }
-            // Line 3: Level + slot/stats
+            // Line 3: Level badge + slot/stats
             val statsParts = mutableListOf<String>()
-            if (item.levelRequirement > 1) statsParts.add("Lv${item.levelRequirement}")
             if (item.slot.isNotEmpty()) statsParts.add(item.slot.replaceFirstChar { it.uppercase() })
             if (item.armorValue > 0) statsParts.add("ARM ${item.armorValue}")
             if (item.damageBonus > 0) {
                 val dmgText = if (item.damageRange > 0) "DMG +${item.damageBonus} (1-${item.damageRange})" else "DMG +${item.damageBonus}"
                 statsParts.add(dmgText)
             }
-            if (statsParts.isNotEmpty()) {
-                Text(
-                    text = statsParts.joinToString(" | "),
-                    fontSize = 11.sp,
-                    color = TorchAmber
-                )
+            if (item.levelRequirement > 1 || statsParts.isNotEmpty()) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (item.levelRequirement > 1) {
+                        Text(
+                            text = "Lv${item.levelRequirement}",
+                            fontSize = 11.sp,
+                            color = if (meetsLevel) AshGray else Color(0xFFCC4444)
+                        )
+                        if (statsParts.isNotEmpty()) {
+                            Text(
+                                text = " | ",
+                                fontSize = 11.sp,
+                                color = TorchAmber
+                            )
+                        }
+                    }
+                    if (statsParts.isNotEmpty()) {
+                        Text(
+                            text = statsParts.joinToString(" | "),
+                            fontSize = 11.sp,
+                            color = TorchAmber
+                        )
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix "Owned: X" text wrapping vertically on narrow iOS screens in the vendor buy panel
- Refactor layout to stack item name, owned count, and stats (level/slot/ARM/DMG) on separate lines
- Item name now gets full width without truncation

## Test plan
- [ ] Open vendor panel on iOS simulator (narrow screen)
- [ ] Verify item names display fully without ellipsis truncation
- [ ] Verify "Owned: X" appears on its own line below the name
- [ ] Verify level/slot/stats line renders cleanly below owned count
- [ ] Check both consumable items (no stats line) and equipment items (with stats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)