### PR TITLE
Add maker test coverage for untested routes and components

### DIFF
--- a/maker/server/__tests__/assets.test.ts
+++ b/maker/server/__tests__/assets.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import request from 'supertest'
+import type { Express } from 'express'
+import { createTestApp } from './helpers.js'
+
+let app: Express
+let cleanup: () => Promise<void>
+
+beforeAll(async () => {
+  const ctx = await createTestApp()
+  app = ctx.app
+  cleanup = ctx.cleanup
+})
+
+afterAll(async () => {
+  await cleanup()
+})
+
+// ─── Upload ──────────────────────────────────────────────────
+
+describe('POST /api/asset-mgmt/upload', () => {
+  it('uploads a file successfully', async () => {
+    const res = await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', 'images/test/hello.webp')
+      .attach('file', Buffer.from('fake-image-data'), 'hello.webp')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(res.body.assetPath).toBe('images/test/hello.webp')
+  })
+
+  it('rejects missing assetPath', async () => {
+    const res = await request(app)
+      .post('/api/asset-mgmt/upload')
+      .attach('file', Buffer.from('data'), 'hello.webp')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/assetPath.*required/i)
+  })
+
+  it('rejects missing file', async () => {
+    const res = await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', 'images/test.webp')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/required/i)
+  })
+
+  it('rejects disallowed file extensions', async () => {
+    const res = await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', 'images/test.exe')
+      .attach('file', Buffer.from('bad'), 'test.exe')
+    expect(res.status).toBe(500) // multer throws Error which becomes 500
+  })
+
+  it('rejects path traversal attempts', async () => {
+    const res = await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', '../../../etc/passwd')
+      .attach('file', Buffer.from('data'), 'passwd.json')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/[Ii]nvalid asset path/)
+  })
+})
+
+// ─── History ─────────────────────────────────────────────────
+
+describe('GET /api/asset-mgmt/history', () => {
+  it('returns depth 0 for new file', async () => {
+    const res = await request(app).get('/api/asset-mgmt/history?path=images/nonexistent.webp')
+    expect(res.status).toBe(200)
+    expect(res.body.depth).toBe(0)
+  })
+
+  it('requires path parameter', async () => {
+    const res = await request(app).get('/api/asset-mgmt/history')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/path.*required/i)
+  })
+
+  it('increments depth after multiple uploads', async () => {
+    // Upload version 1
+    await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', 'images/hist_test.webp')
+      .attach('file', Buffer.from('version-1'), 'hist_test.webp')
+
+    // Upload version 2 (creates backup of v1)
+    await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', 'images/hist_test.webp')
+      .attach('file', Buffer.from('version-2'), 'hist_test.webp')
+
+    const res = await request(app).get('/api/asset-mgmt/history?path=images/hist_test.webp')
+    expect(res.status).toBe(200)
+    expect(res.body.depth).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ─── Undo ────────────────────────────────────────────────────
+
+describe('POST /api/asset-mgmt/undo', () => {
+  it('requires assetPath', async () => {
+    const res = await request(app).post('/api/asset-mgmt/undo').send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/assetPath.*required/i)
+  })
+
+  it('returns 404 when no history available', async () => {
+    const res = await request(app)
+      .post('/api/asset-mgmt/undo')
+      .send({ assetPath: 'images/no_history.webp' })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toMatch(/[Nn]o history/)
+  })
+
+  it('restores previous version', async () => {
+    // Upload twice to create history
+    await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', 'images/undo_test.webp')
+      .attach('file', Buffer.from('original'), 'undo_test.webp')
+    await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', 'images/undo_test.webp')
+      .attach('file', Buffer.from('modified'), 'undo_test.webp')
+
+    const res = await request(app)
+      .post('/api/asset-mgmt/undo')
+      .send({ assetPath: 'images/undo_test.webp' })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+})
+
+// ─── Clear ───────────────────────────────────────────────────
+
+describe('POST /api/asset-mgmt/clear', () => {
+  it('requires assetPath', async () => {
+    const res = await request(app).post('/api/asset-mgmt/clear').send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/assetPath.*required/i)
+  })
+
+  it('clears an existing file', async () => {
+    // Upload a file first
+    await request(app)
+      .post('/api/asset-mgmt/upload')
+      .field('assetPath', 'images/clear_test.webp')
+      .attach('file', Buffer.from('to-be-cleared'), 'clear_test.webp')
+
+    const res = await request(app)
+      .post('/api/asset-mgmt/clear')
+      .send({ assetPath: 'images/clear_test.webp' })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+
+  it('succeeds even for non-existent file', async () => {
+    const res = await request(app)
+      .post('/api/asset-mgmt/clear')
+      .send({ assetPath: 'images/doesnt_exist.webp' })
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+})

--- a/maker/server/__tests__/export.test.ts
+++ b/maker/server/__tests__/export.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import request from 'supertest'
+import type { Express } from 'express'
+import { createTestApp } from './helpers.js'
+
+let app: Express
+let cleanup: () => Promise<void>
+
+beforeAll(async () => {
+  const ctx = await createTestApp()
+  app = ctx.app
+  cleanup = ctx.cleanup
+})
+
+afterAll(async () => {
+  await cleanup()
+})
+
+// ─── JSON Export ──────────────────────────────────────────────
+
+describe('GET /api/export/json', () => {
+  it('returns structured world data from empty project', async () => {
+    const res = await request(app).get('/api/export/json')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('zones')
+    expect(res.body).toHaveProperty('items')
+    expect(res.body).toHaveProperty('classes')
+    expect(res.body).toHaveProperty('races')
+    expect(res.body).toHaveProperty('skills')
+    expect(res.body).toHaveProperty('spells')
+    expect(res.body).toHaveProperty('recipes')
+  })
+
+  it('returns empty catalogs for fresh project', async () => {
+    const res = await request(app).get('/api/export/json')
+    expect(res.status).toBe(200)
+    // Fresh project has no user-created classes or races
+    expect(typeof res.body.classes).toBe('object')
+    expect(typeof res.body.races).toBe('object')
+  })
+
+  it('includes created items in export', async () => {
+    // Create an item first
+    await request(app).post('/api/items').send({
+      id: 'export_sword',
+      name: 'Export Sword',
+      description: 'For export testing',
+      type: 'weapon',
+      slot: 'weapon',
+      damageBonus: 5,
+      damageRange: 3,
+    })
+
+    const res = await request(app).get('/api/export/json')
+    expect(res.status).toBe(200)
+    expect(res.body.items).toHaveProperty('export_sword')
+    expect(res.body.items.export_sword.name).toBe('Export Sword')
+    expect(res.body.items.export_sword.damageBonus).toBe(5)
+  })
+
+  it('includes zone and room data in export', async () => {
+    // Create a zone with a room
+    await request(app).post('/api/zones').send({
+      id: 'export_zone',
+      name: 'Export Zone',
+      description: 'Zone for export testing',
+    })
+    await request(app).post('/api/zones/export_zone/rooms').send({
+      id: 'export_zone:room1',
+      name: 'Room One',
+      description: 'First room',
+      x: 0,
+      y: 0,
+    })
+
+    const res = await request(app).get('/api/export/json')
+    expect(res.status).toBe(200)
+    expect(res.body.zones).toHaveProperty('export_zone')
+    expect(res.body.zones.export_zone.name).toBe('Export Zone')
+    expect(res.body.zones.export_zone.rooms).toHaveProperty('export_zone:room1')
+  })
+})
+
+// ─── Validation ───────────────────────────────────────────────
+
+describe('GET /api/export/validate', () => {
+  it('returns validation result object', async () => {
+    const res = await request(app).get('/api/export/validate')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('errors')
+    expect(res.body).toHaveProperty('warnings')
+    expect(Array.isArray(res.body.errors)).toBe(true)
+    expect(Array.isArray(res.body.warnings)).toBe(true)
+  })
+
+  it('reports missing spawnRoom as error', async () => {
+    const res = await request(app).get('/api/export/validate')
+    expect(res.status).toBe(200)
+    // New projects don't have a spawnRoom set
+    const spawnError = res.body.errors.find((e: string) => e.includes('spawnRoom'))
+    expect(spawnError).toBeDefined()
+  })
+
+  it('reports warnings for incomplete entities', async () => {
+    // The export_sword we created earlier has no attackSound/missSound
+    const res = await request(app).get('/api/export/validate')
+    expect(res.status).toBe(200)
+    expect(res.body.warnings.length).toBeGreaterThan(0)
+  })
+})
+
+// ─── NMD Export ───────────────────────────────────────────────
+
+describe('GET /api/export/nmd', () => {
+  it('returns ZIP with correct content-type', async () => {
+    const res = await request(app).get('/api/export/nmd')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toMatch(/application\/zip/)
+    expect(res.headers['content-disposition']).toMatch(/\.nmd/)
+    expect(res.body).toBeTruthy()
+  })
+})
+
+// ─── Package (validate then export) ──────────────────────────
+
+describe('GET /api/export/package', () => {
+  it('returns 400 with errors when validation fails', async () => {
+    // No spawnRoom → validation error → package refused
+    const res = await request(app).get('/api/export/package')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('errors')
+    expect(res.body.errors.length).toBeGreaterThan(0)
+  })
+})
+
+// ─── Package with valid project ──────────────────────────────
+
+describe('Package with spawnRoom set', () => {
+  let validApp: Express
+  let validCleanup: () => Promise<void>
+
+  beforeAll(async () => {
+    const ctx = await createTestApp()
+    validApp = ctx.app
+    validCleanup = ctx.cleanup
+
+    // Set up a minimal valid project: zone with spawnRoom
+    await request(validApp).post('/api/zones').send({
+      id: 'test_zone',
+      name: 'Test Zone',
+      description: 'Valid zone',
+      spawnRoom: 'test_zone:spawn',
+    })
+    await request(validApp).post('/api/zones/test_zone/rooms').send({
+      id: 'test_zone:spawn',
+      name: 'Spawn Room',
+      description: 'Starting room',
+      x: 0,
+      y: 0,
+    })
+  })
+
+  afterAll(async () => {
+    await validCleanup()
+  })
+
+  it('succeeds when only warnings exist (no blocking errors)', async () => {
+    // Use /nmd directly (no validation) to confirm bundle builds
+    const res = await request(validApp).get('/api/export/nmd')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toMatch(/application\/zip/)
+  })
+
+  it('validation passes with spawnRoom set (no errors)', async () => {
+    const res = await request(validApp).get('/api/export/validate')
+    expect(res.status).toBe(200)
+    expect(res.body.errors).toHaveLength(0)
+    // Warnings may still exist (missing sounds, etc.)
+    expect(Array.isArray(res.body.warnings)).toBe(true)
+  })
+})

--- a/maker/server/__tests__/helpers.ts
+++ b/maker/server/__tests__/helpers.ts
@@ -10,6 +10,7 @@ import { projectsRouter } from '../routes/projects.js'
 import { exportRouter } from '../routes/export.js'
 import { pcSpritesRouter } from '../routes/pcSprites.js'
 import { defaultSfxRouter } from '../routes/defaultSfx.js'
+import { assetMgmtRouter } from '../routes/assets.js'
 import { createProject, deleteProject } from '../db.js'
 import { getProjectsDir, getProjectClient, assetsRoot } from '../projectContext.js'
 
@@ -82,6 +83,7 @@ export async function createTestApp(projectName?: string): Promise<{
   app.use('/api/export', exportRouter)
   app.use('/api/pc-sprites', pcSpritesRouter)
   app.use('/api/default-sfx', defaultSfxRouter)
+  app.use('/api/asset-mgmt', assetMgmtRouter)
 
   const cleanup = async () => {
     try {
@@ -128,6 +130,7 @@ export async function createReadOnlyTestApp(): Promise<{
   app.use('/api/export', exportRouter)
   app.use('/api/pc-sprites', pcSpritesRouter)
   app.use('/api/default-sfx', defaultSfxRouter)
+  app.use('/api/asset-mgmt', assetMgmtRouter)
 
   const cleanup = async () => {
     try {

--- a/maker/src/__tests__/MenuBar.test.tsx
+++ b/maker/src/__tests__/MenuBar.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+vi.mock('../api', () => {
+  return {
+    default: {
+      get: vi.fn().mockResolvedValue({ errors: [], warnings: [] }),
+      post: vi.fn().mockResolvedValue({}),
+    },
+  }
+})
+
+import api from '../api'
+import MenuBar from '../components/MenuBar'
+
+const mockApi = vi.mocked(api)
+
+function renderMenuBar() {
+  return render(
+    <MemoryRouter initialEntries={['/project/test_project/zones']}>
+      <Routes>
+        <Route path="/project/:name/*" element={<MenuBar />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('MenuBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.get.mockResolvedValue({ errors: [], warnings: [] })
+  })
+
+  it('renders menu buttons', () => {
+    renderMenuBar()
+    expect(screen.getByText('Save As')).toBeInTheDocument()
+    expect(screen.getByText('Switch Project')).toBeInTheDocument()
+    expect(screen.getByText('Validate')).toBeInTheDocument()
+    expect(screen.getByText('Export .nmd')).toBeInTheDocument()
+    expect(screen.getByText('Package .nmd')).toBeInTheDocument()
+    expect(screen.getByText('Quit Server')).toBeInTheDocument()
+  })
+
+  it('Validate button calls API and shows modal on success', async () => {
+    const user = userEvent.setup()
+    mockApi.get.mockResolvedValue({ errors: [], warnings: [] })
+    renderMenuBar()
+
+    await user.click(screen.getByText('Validate'))
+
+    await waitFor(() => {
+      expect(mockApi.get).toHaveBeenCalledWith('/export/validate')
+    })
+    // Modal should appear with validation passed
+    expect(screen.getByText('Validation Results')).toBeInTheDocument()
+    expect(screen.getByText(/[Vv]alidation passed/)).toBeInTheDocument()
+  })
+
+  it('Validate shows errors in modal', async () => {
+    const user = userEvent.setup()
+    mockApi.get.mockResolvedValue({ errors: ['No spawnRoom'], warnings: [] })
+    renderMenuBar()
+
+    await user.click(screen.getByText('Validate'))
+
+    await waitFor(() => {
+      expect(screen.getByText('No spawnRoom')).toBeInTheDocument()
+    })
+  })
+
+  it('Validate modal can be closed', async () => {
+    const user = userEvent.setup()
+    mockApi.get.mockResolvedValue({ errors: [], warnings: [] })
+    renderMenuBar()
+
+    await user.click(screen.getByText('Validate'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Validation Results')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Close'))
+    expect(screen.queryByText('Validation Results')).not.toBeInTheDocument()
+  })
+
+  it('Package with errors shows modal with errors', async () => {
+    const user = userEvent.setup()
+    mockApi.get.mockResolvedValue({ errors: ['Missing spawnRoom'], warnings: [] })
+    renderMenuBar()
+
+    await user.click(screen.getByText('Package .nmd'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Missing spawnRoom')).toBeInTheDocument()
+    })
+    // Should NOT show Package Anyway button since there are errors
+    expect(screen.queryByText('Package Anyway')).not.toBeInTheDocument()
+  })
+
+  it('Package with warnings shows modal with action button', async () => {
+    const user = userEvent.setup()
+    mockApi.get.mockResolvedValue({ errors: [], warnings: ['Missing sound'] })
+    renderMenuBar()
+
+    await user.click(screen.getByText('Package .nmd'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Missing sound')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Package Anyway')).toBeInTheDocument()
+  })
+
+  it('Validate shows error modal on API failure', async () => {
+    const user = userEvent.setup()
+    mockApi.get.mockRejectedValue(new Error('Network error'))
+    renderMenuBar()
+
+    await user.click(screen.getByText('Validate'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+})

--- a/maker/src/__tests__/SettingsEditor.test.tsx
+++ b/maker/src/__tests__/SettingsEditor.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+vi.mock('../api', () => {
+  return {
+    default: {
+      get: vi.fn().mockResolvedValue({}),
+      put: vi.fn().mockResolvedValue({ ok: true }),
+      post: vi.fn().mockResolvedValue({ ok: true, testedAt: new Date().toISOString() }),
+    },
+  }
+})
+
+function makeDefaultSettings() {
+  return {
+    providers: {
+      'stable-diffusion': { label: 'Stable Diffusion', apiUrl: 'http://localhost:7860', apiKey: '' },
+      openai: { label: 'OpenAI', apiUrl: 'https://api.openai.com/v1', apiKey: 'sk-test' },
+      elevenlabs: { label: 'ElevenLabs', apiUrl: 'https://api.elevenlabs.io/v1', apiKey: '' },
+    },
+    customProviders: [] as any[],
+    imageProvider: 'stable-diffusion',
+    soundProvider: 'elevenlabs',
+    providerStatus: {} as Record<string, any>,
+  }
+}
+
+import api from '../api'
+import SettingsEditor from '../pages/SettingsEditor'
+
+const mockApi = vi.mocked(api)
+
+describe('SettingsEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.get.mockResolvedValue(makeDefaultSettings())
+    mockApi.put.mockResolvedValue({ ok: true })
+  })
+
+  it('loads and renders settings from API', async () => {
+    render(<SettingsEditor />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument()
+    })
+    expect(mockApi.get).toHaveBeenCalledWith('/settings')
+    expect(screen.getByText('Built-in Providers')).toBeInTheDocument()
+    expect(screen.getByText('Active Providers')).toBeInTheDocument()
+  })
+
+  it('renders built-in provider inputs', async () => {
+    render(<SettingsEditor />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('http://localhost:7860')).toBeInTheDocument()
+    })
+    expect(screen.getByDisplayValue('https://api.openai.com/v1')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('https://api.elevenlabs.io/v1')).toBeInTheDocument()
+  })
+
+  it('save button calls api.put with settings', async () => {
+    const user = userEvent.setup()
+    render(<SettingsEditor />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Save Settings')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Save Settings'))
+
+    await waitFor(() => {
+      expect(mockApi.put).toHaveBeenCalledWith('/settings', expect.objectContaining({
+        imageProvider: 'stable-diffusion',
+        soundProvider: 'elevenlabs',
+      }))
+    })
+  })
+
+  it('add custom provider creates a new entry', async () => {
+    const user = userEvent.setup()
+    render(<SettingsEditor />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Provider')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Add Provider'))
+
+    // Should show a remove button for the new provider
+    expect(screen.getByText('Remove')).toBeInTheDocument()
+    // Should show the provider name input
+    expect(screen.getByPlaceholderText('Provider name')).toBeInTheDocument()
+  })
+
+  it('remove custom provider deletes entry', async () => {
+    const user = userEvent.setup()
+    mockApi.get.mockResolvedValue({
+      ...makeDefaultSettings(),
+      customProviders: [
+        { id: 'custom_1', label: 'My Provider', apiUrl: 'http://custom.test', apiKey: '' },
+      ],
+    })
+
+    render(<SettingsEditor />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('My Provider')).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByText('Remove'))
+
+    expect(screen.queryByDisplayValue('My Provider')).not.toBeInTheDocument()
+  })
+
+  it('test button calls api.post for provider', async () => {
+    const user = userEvent.setup()
+    mockApi.post.mockResolvedValue({ ok: true, testedAt: new Date().toISOString() })
+    render(<SettingsEditor />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings')).toBeInTheDocument()
+    })
+
+    // There are multiple "Test" buttons; click the first one (active image provider)
+    const testButtons = screen.getAllByText('Test')
+    await user.click(testButtons[0])
+
+    await waitFor(() => {
+      expect(mockApi.post).toHaveBeenCalledWith('/settings/test-provider', expect.objectContaining({
+        providerId: expect.any(String),
+      }))
+    })
+  })
+
+  it('renders nothing before settings load', () => {
+    // Make API hang
+    mockApi.get.mockReturnValue(new Promise(() => {}))
+    const { container } = render(<SettingsEditor />)
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/maker/src/__tests__/SfxPreview.test.tsx
+++ b/maker/src/__tests__/SfxPreview.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+vi.mock('../api', () => {
+  return {
+    default: {
+      get: vi.fn().mockResolvedValue({ depth: 0 }),
+      post: vi.fn().mockResolvedValue({ ok: true }),
+      upload: vi.fn().mockResolvedValue({ ok: true }),
+    },
+  }
+})
+
+import api from '../api'
+import SfxPreview from '../components/SfxPreview'
+
+const mockApi = vi.mocked(api)
+
+describe('SfxPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.get.mockResolvedValue({ depth: 0 })
+    mockApi.post.mockResolvedValue({ ok: true })
+  })
+
+  it('renders sound ID input and buttons', () => {
+    render(<SfxPreview soundId="test_sound" onSoundIdChange={vi.fn()} />)
+    expect(screen.getByDisplayValue('test_sound')).toBeInTheDocument()
+    expect(screen.getByText('Play')).toBeInTheDocument()
+    expect(screen.getByText('AI')).toBeInTheDocument()
+    expect(screen.getByText('Up')).toBeInTheDocument()
+    expect(screen.getByText('Undo')).toBeInTheDocument()
+    expect(screen.getByText('X')).toBeInTheDocument()
+  })
+
+  it('Play button is disabled when no soundId', () => {
+    render(<SfxPreview soundId="" onSoundIdChange={vi.fn()} />)
+    expect(screen.getByText('Play')).toBeDisabled()
+  })
+
+  it('X (clear) button is disabled when no soundId', () => {
+    render(<SfxPreview soundId="" onSoundIdChange={vi.fn()} />)
+    expect(screen.getByText('X')).toBeDisabled()
+  })
+
+  it('Undo button is disabled when undoDepth=0', () => {
+    render(<SfxPreview soundId="test" onSoundIdChange={vi.fn()} />)
+    expect(screen.getByText('Undo')).toBeDisabled()
+  })
+
+  it('Undo button enabled when undoDepth > 0', async () => {
+    mockApi.get.mockResolvedValue({ depth: 2 })
+    render(<SfxPreview soundId="test" onSoundIdChange={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByText('Undo')).not.toBeDisabled()
+    })
+  })
+
+  it('calls onSoundIdChange when input changes', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SfxPreview soundId="" onSoundIdChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('sound_id')
+    await user.type(input, 'a')
+    expect(onChange).toHaveBeenCalledWith('a')
+  })
+
+  it('AI button opens popover with prompt field', async () => {
+    const user = userEvent.setup()
+    render(<SfxPreview soundId="test" onSoundIdChange={vi.fn()} />)
+
+    await user.click(screen.getByText('AI'))
+    expect(screen.getByText('SFX Prompt')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Describe the sound effect...')).toBeInTheDocument()
+    expect(screen.getByText('Generate')).toBeInTheDocument()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+  })
+
+  it('AI popover closes on Cancel', async () => {
+    const user = userEvent.setup()
+    render(<SfxPreview soundId="test" onSoundIdChange={vi.fn()} />)
+
+    await user.click(screen.getByText('AI'))
+    expect(screen.getByText('SFX Prompt')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Cancel'))
+    expect(screen.queryByText('SFX Prompt')).not.toBeInTheDocument()
+  })
+
+  it('AI popover pre-fills prompt from entityLabel', async () => {
+    const user = userEvent.setup()
+    render(<SfxPreview soundId="test" onSoundIdChange={vi.fn()} entityLabel="Dragon Attack" />)
+
+    await user.click(screen.getByText('AI'))
+    const textarea = screen.getByPlaceholderText('Describe the sound effect...')
+    expect((textarea as HTMLTextAreaElement).value).toBe('Dragon Attack sound effect')
+  })
+
+  it('Generate calls API and closes popover', async () => {
+    const user = userEvent.setup()
+    render(
+      <SfxPreview
+        soundId="test"
+        onSoundIdChange={vi.fn()}
+        audioCategory="npcs"
+        initialPrompt="A dragon roar"
+      />
+    )
+
+    await user.click(screen.getByText('AI'))
+    await user.click(screen.getByText('Generate'))
+
+    await waitFor(() => {
+      expect(mockApi.post).toHaveBeenCalledWith('/generate/sound', {
+        prompt: 'A dragon roar',
+        duration: 5,
+        assetPath: 'audio/npcs/test.mp3',
+      })
+    })
+  })
+
+  it('calls onPromptChange when prompt is edited', async () => {
+    const user = userEvent.setup()
+    const onPromptChange = vi.fn()
+    render(
+      <SfxPreview
+        soundId="test"
+        onSoundIdChange={vi.fn()}
+        initialPrompt=""
+        onPromptChange={onPromptChange}
+      />
+    )
+
+    await user.click(screen.getByText('AI'))
+    const textarea = screen.getByPlaceholderText('Describe the sound effect...')
+    await user.type(textarea, 'x')
+
+    expect(onPromptChange).toHaveBeenCalled()
+  })
+})

--- a/maker/src/__tests__/ValidationModal.test.tsx
+++ b/maker/src/__tests__/ValidationModal.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect } from 'vitest'
+import ValidationModal from '../components/ValidationModal'
+
+describe('ValidationModal', () => {
+  it('shows success message when no errors or warnings', () => {
+    render(<ValidationModal errors={[]} warnings={[]} onClose={vi.fn()} />)
+    expect(screen.getByText(/[Vv]alidation passed/)).toBeInTheDocument()
+  })
+
+  it('renders error count and items', () => {
+    render(
+      <ValidationModal
+        errors={['Missing spawnRoom', 'Invalid NPC']}
+        warnings={[]}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Errors \(2\)/)).toBeInTheDocument()
+    expect(screen.getByText('Missing spawnRoom')).toBeInTheDocument()
+    expect(screen.getByText('Invalid NPC')).toBeInTheDocument()
+  })
+
+  it('renders warning count and items', () => {
+    render(
+      <ValidationModal
+        errors={[]}
+        warnings={['Weapon missing sound', 'NPC missing loot']}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Warnings \(2\)/)).toBeInTheDocument()
+    expect(screen.getByText('Weapon missing sound')).toBeInTheDocument()
+    expect(screen.getByText('NPC missing loot')).toBeInTheDocument()
+  })
+
+  it('renders both errors and warnings', () => {
+    render(
+      <ValidationModal
+        errors={['Error 1']}
+        warnings={['Warning 1']}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Errors \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Warnings \(1\)/)).toBeInTheDocument()
+  })
+
+  it('calls onClose when Close button clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<ValidationModal errors={[]} warnings={[]} onClose={onClose} />)
+
+    await user.click(screen.getByText('Close'))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when overlay clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const { container } = render(
+      <ValidationModal errors={[]} warnings={[]} onClose={onClose} />
+    )
+
+    // Click the overlay (outermost div)
+    const overlay = container.firstElementChild as HTMLElement
+    await user.click(overlay)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows action button when errors=0, warnings>0, and actionLabel provided', () => {
+    render(
+      <ValidationModal
+        errors={[]}
+        warnings={['Some warning']}
+        onClose={vi.fn()}
+        actionLabel="Package Anyway"
+        onAction={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Package Anyway')).toBeInTheDocument()
+  })
+
+  it('hides action button when errors present', () => {
+    render(
+      <ValidationModal
+        errors={['Error']}
+        warnings={['Warning']}
+        onClose={vi.fn()}
+        actionLabel="Package Anyway"
+        onAction={vi.fn()}
+      />
+    )
+    expect(screen.queryByText('Package Anyway')).not.toBeInTheDocument()
+  })
+
+  it('hides action button when no actionLabel', () => {
+    render(
+      <ValidationModal
+        errors={[]}
+        warnings={['Warning']}
+        onClose={vi.fn()}
+      />
+    )
+    // Only Close button should be present
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(1)
+    expect(buttons[0]).toHaveTextContent('Close')
+  })
+
+  it('calls onAction and onClose when action button clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onAction = vi.fn()
+    render(
+      <ValidationModal
+        errors={[]}
+        warnings={['Warning']}
+        onClose={onClose}
+        actionLabel="Package Anyway"
+        onAction={onAction}
+      />
+    )
+
+    await user.click(screen.getByText('Package Anyway'))
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(onAction).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary
- Add 60 new maker tests (330 → 390 total) across 6 new test files
- Cover previously untested server routes: export (JSON/NMD/validate/package) and asset management (upload/undo/clear/history/path traversal)
- Cover previously untested UI components: ValidationModal, SfxPreview, SettingsEditor, MenuBar
- Wire `assetMgmtRouter` into test helpers so asset routes are testable

## Test plan
- [x] All 390 maker tests pass (`cd maker && npm run test`)
- [x] All 330 existing tests still pass (no regressions)
- [ ] Verify server/shared Kotlin tests unaffected (`./gradlew :shared:jvmTest :server:test` — not runnable in remote env, needs CI)

https://claude.ai/code/session_01RKZjjMAEe6xjkQdTcLdVCN