### PR TITLE
Production promotion workflow, release.yml demotion, WASM Sentry environment tag

### DIFF
--- a/.github/workflows/promote-server.yml
+++ b/.github/workflows/promote-server.yml
@@ -1,0 +1,166 @@
+name: Promote Game Server to Production
+
+# Manual-only promotion: retags the staging-validated :latest images to :prod
+# (no rebuild — promotion means shipping exactly what staging validated),
+# pulls them on the production droplet, and publishes the world bundle via
+# the production platform API. Gated by the GitHub "production" environment.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: "[1/7] Log in to GHCR"
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "[2/7] Retag :latest → :prod (registry-side, no rebuild)"
+        run: |
+          echo "[2/7] Promoting staging-validated images to :prod..."
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository_owner }}/neomud-server:prod \
+            ghcr.io/${{ github.repository_owner }}/neomud-server:latest
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository_owner }}/neomud-maker:prod \
+            ghcr.io/${{ github.repository_owner }}/neomud-maker:latest
+          echo "[2/7] ✓ Images retagged"
+
+      - name: "[3/7] Pull :prod images on production droplet"
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            echo "[3/7] Pulling :prod images..."
+            docker pull ghcr.io/${{ github.repository_owner }}/neomud-server:prod
+            docker pull ghcr.io/${{ github.repository_owner }}/neomud-maker:prod
+            docker image prune -f
+            echo "[3/7] ✓ Images ready"
+
+      - name: "[4/7] Build world bundle"
+        run: |
+          echo "[4/7] Building world bundle..."
+          ./gradlew packageWorld --rerun-tasks
+          ls -lh server/build/worlds/default-world.nmd || { echo "[4/7] ✗ FATAL: world bundle not found"; exit 1; }
+          echo "[4/7] ✓ World bundle built"
+
+      - name: "[5/7] Upload seed bundle (first-boot safety net)"
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          source: "server/build/worlds/default-world.nmd"
+          target: /srv/neomud-assets/
+          strip_components: 3
+          overwrite: true
+
+      - name: "[6/7] Publish world via API + verify"
+        env:
+          PROD_API: https://api.neomud.app
+          ADMIN_EMAIL: ${{ secrets.PROD_ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.PROD_ADMIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          VERSION=$(jq -r .version maker/default_world_src/manifest.json)
+          CHANGELOG=$(jq -r '.releaseNotes // empty' maker/default_world_src/manifest.json)
+          if [ -z "$CHANGELOG" ]; then
+            echo "❌ manifest.json is missing releaseNotes — add release notes before deploying"
+            exit 1
+          fi
+
+          echo "Publishing default-world v${VERSION}..."
+
+          # 1) Authenticate (retry up to 3× on rate-limit 429)
+          TOKEN=""
+          for attempt in 1 2 3; do
+            LOGIN_RESP=$(curl -sS -w '\n%{http_code}' -X POST "$PROD_API/api/v1/auth/login" \
+              -H "Content-Type: application/json" \
+              -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}")
+            LOGIN_HTTP=$(echo "$LOGIN_RESP" | tail -1)
+            LOGIN_BODY=$(echo "$LOGIN_RESP" | sed '$d')
+            if [ "$LOGIN_HTTP" = "200" ]; then
+              TOKEN=$(echo "$LOGIN_BODY" | jq -r '.accessToken')
+              break
+            fi
+            if [ "$LOGIN_HTTP" = "429" ] && [ "$attempt" -lt 3 ]; then
+              WAIT=$(echo "$LOGIN_BODY" | jq -r '.retryAfterSeconds // 60')
+              echo "  Rate limited, waiting ${WAIT}s (attempt $attempt/3)..."
+              sleep "$WAIT"
+            else
+              echo "❌ Login failed (HTTP $LOGIN_HTTP): $LOGIN_BODY"
+              exit 1
+            fi
+          done
+          [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || { echo "❌ Login failed after retries"; exit 1; }
+          echo "✓ Authenticated"
+
+          # 2) Resolve world ID from slug
+          WORLD_ID=$(curl -fsS "$PROD_API/api/v1/worlds/default-world" \
+            | jq -r '.id')
+          [ -n "$WORLD_ID" ] && [ "$WORLD_ID" != "null" ] || { echo "❌ World not found"; exit 1; }
+          echo "✓ World ID: $WORLD_ID"
+
+          # 3) Publish version (uploads bundle, retires old, auto-starts)
+          HTTP_CODE=$(curl -sS -o /tmp/publish-response.json -w '%{http_code}' \
+            -X POST "$PROD_API/api/v1/worlds/$WORLD_ID/versions" \
+            -H "Authorization: Bearer $TOKEN" \
+            -F "version=$VERSION" \
+            -F "changelog=$CHANGELOG" \
+            -F "bundle=@server/build/worlds/default-world.nmd")
+          if [ "$HTTP_CODE" = "409" ]; then
+            echo "❌ Version $VERSION already exists — bump version in maker/default_world_src/manifest.json"
+            echo "   Without a new version, the container will NOT restart with the new Docker image."
+            echo "   This is the #1 cause of 'deploy succeeded but staging is broken.'"
+            exit 1
+          elif [ "$HTTP_CODE" -ge 400 ]; then
+            echo "❌ Publish failed (HTTP $HTTP_CODE):"
+            cat /tmp/publish-response.json
+            exit 1
+          else
+            echo "✓ Published: $(jq -c '{id,version,checksum}' /tmp/publish-response.json)"
+          fi
+
+          # 4) Poll until game server is ONLINE (150s timeout)
+          echo "Waiting for game server..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -fsS "$PROD_API/api/v1/worlds/default-world" \
+              | jq -r '.serverStatus // "UNKNOWN"')
+            if [ "$STATUS" = "ONLINE" ]; then
+              echo "✅ Game server ONLINE — v${VERSION} deployed"
+              exit 0
+            fi
+            echo "  [$i/30] serverStatus=$STATUS"
+            sleep 5
+          done
+          echo "⚠️ Game server not ONLINE after 150s (status=$STATUS)"
+          exit 1
+
+      - name: "[7/7] Promotion summary"
+        run: |
+          echo "✅ Promotion complete:"
+          echo "  - neomud-server:prod and neomud-maker:prod retagged from :latest"
+          echo "  - Images pulled on production droplet"
+          echo "  - World bundle published via $PROD_API"
+        env:
+          PROD_API: https://api.neomud.app

--- a/.github/workflows/promote-server.yml
+++ b/.github/workflows/promote-server.yml
@@ -4,6 +4,11 @@ name: Promote Game Server to Production
 # (no rebuild — promotion means shipping exactly what staging validated),
 # pulls them on the production droplet, and publishes the world bundle via
 # the production platform API. Gated by the GitHub "production" environment.
+#
+# CONTRACT: dispatch this only when master HEAD matches the commit the last
+# staging deploy built — the :latest image carries that commit's JAR, while
+# the world bundle in step [4/7] is rebuilt from THIS checkout. Promoting
+# with not-yet-staged commits on master ships a JAR/world-data skew.
 on:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,13 +65,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Version-tag only — :latest is owned by the staging deploy workflows
+      # and :prod by promote-server.yml. Release builds are pure artifacts.
       - name: Build and push game server image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/neomud-server:latest
             ghcr.io/${{ github.repository_owner }}/neomud-server:${{ github.ref_name }}
 
       - name: Build and push maker image
@@ -80,36 +81,4 @@ jobs:
           context: ./maker
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/neomud-maker:latest
             ghcr.io/${{ github.repository_owner }}/neomud-maker:${{ github.ref_name }}
-
-      - name: Deploy to VPS
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY_STAGING }}
-          script: |
-            docker pull ghcr.io/${{ github.repository_owner }}/neomud-server:latest
-            docker pull ghcr.io/${{ github.repository_owner }}/neomud-maker:latest
-            docker image prune -f
-
-      - name: Upload world bundle and WASM client to VPS
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY_STAGING }}
-          source: "server/build/worlds/default-world.nmd"
-          target: /srv/neomud-assets/
-          strip_components: 3
-
-      - name: Upload WASM client to VPS
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY_STAGING }}
-          source: "client/build/dist/wasmJs/productionExecutable/*"
-          target: /srv/neomud-wasm-stage/
-          strip_components: 5

--- a/client/src/wasmJsMain/resources/index.html
+++ b/client/src/wasmJsMain/resources/index.html
@@ -296,11 +296,14 @@
     <!-- Environment tag: staging for stage-*/localhost hosts, production otherwise -->
     <script>
         window.sentryOnLoad = function () {
-            Sentry.init({
-                environment: location.hostname.indexOf("stage") === 0 || location.hostname.indexOf("localhost") === 0
-                    ? "staging"
-                    : "production",
-            });
+            var env = location.hostname.indexOf("stage") === 0 || location.hostname.indexOf("localhost") === 0
+                ? "staging"
+                : "production";
+            // Sentry.init option-merge inside sentryOnLoad only works on
+            // SDK v8+ (v7 silently ignores a second init). setTag works on
+            // both, so the environment label survives either loader SDK.
+            Sentry.setTag("environment", env);
+            Sentry.init({ environment: env });
         };
     </script>
     <script src="https://js.sentry-cdn.com/ed49ac2687b7b9cc5c0cd45c2bf1e1f1.min.js" crossorigin="anonymous"></script>

--- a/client/src/wasmJsMain/resources/index.html
+++ b/client/src/wasmJsMain/resources/index.html
@@ -293,6 +293,16 @@
         }, 300000);
     </script>
     <!-- Sentry error tracking (CDN loader with baked-in DSN, catches all JS errors) -->
+    <!-- Environment tag: staging for stage-*/localhost hosts, production otherwise -->
+    <script>
+        window.sentryOnLoad = function () {
+            Sentry.init({
+                environment: location.hostname.indexOf("stage") === 0 || location.hostname.indexOf("localhost") === 0
+                    ? "staging"
+                    : "production",
+            });
+        };
+    </script>
     <script src="https://js.sentry-cdn.com/ed49ac2687b7b9cc5c0cd45c2bf1e1f1.min.js" crossorigin="anonymous"></script>
     <script src="neomud-audio.js"></script>
     <script src="neomud.js"></script>


### PR DESCRIPTION
## Summary

Game-repo half of the staging→production launch plan (Phase 1C):

- **New `promote-server.yml`** (manual, `production`-environment-gated): registry-side retag `neomud-server:latest` + `neomud-maker:latest` → `:prod` (no rebuild — promote what staging validated), pull on the prod droplet, upload seed bundle, publish the world version via `https://api.neomud.app` with `PROD_ADMIN_*` credentials. Version-bump + releaseNotes gates carried over verbatim from deploy-server.yml.
- **`release.yml` demoted to pure artifact builder**: VPS deploy/upload steps removed, `:latest` image tags dropped (owned by staging deploys; `:prod` by promote-server.yml) — fixes the staging-path collision on `v*` tags.
- **WASM client Sentry environment tag**: `window.sentryOnLoad` hook tags staging vs production by hostname (setTag + init for v7/v8 loader compatibility) — prod errors stop landing untagged in the shared client project.

New GH secrets needed (production environment): `PROD_HOST`, `PROD_USER`, `PROD_SSH_KEY`, `PROD_ADMIN_EMAIL`, `PROD_ADMIN_PASSWORD`.

Companion PR: roomsmith-games/NeoMud-Platform#52

## Testing
- Workflow YAML validated; publish block is a verbatim clone of the battle-tested deploy-server.yml step with only URL/secret renames (verified by review agent)
- release.yml checked for dangling step references — none
- Sentry hook verified placed before the CDN loader tag; hostname matrix checked (stage.*, localhost → staging; neomud.app, play.* → production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)